### PR TITLE
Update magic essense and magic ruestone drop rate for dark meadows.

### DIFF
--- a/DropTables/drop_that.character_drop.EVEliteBosses.cfg
+++ b/DropTables/drop_that.character_drop.EVEliteBosses.cfg
@@ -1,8 +1,8 @@
 [RRRM_EliteBoar.0]
-PrefabName = Coins
-SetAmountMin = 8
-SetAmountMax = 12
-SetChanceToDrop = 0
+PrefabName = RawMeat
+SetAmountMin = 1
+SetAmountMax = 5
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -13,7 +13,7 @@ ConditionMaxLevel= 1
 PrefabName = EssenceMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 100
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -24,7 +24,7 @@ ConditionMaxLevel= 1
 PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 10
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -43,10 +43,10 @@ ConditionMinLevel= 1
 ConditionMaxLevel= 1
 
 [RRRM_EliteBoar.4]
-PrefabName = Stone
+PrefabName = LeatherScraps
 SetAmountMin = 1
-SetAmountMax = 1
-SetChanceToDrop = 0
+SetAmountMax = 3
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -66,9 +66,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteBoarI.1]
 PrefabName = EssenceMagic
-SetAmountMin = 2
+SetAmountMin = 1
 SetAmountMax = 2
-SetChanceToDrop = 100
+SetChanceToDrop = 75
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -77,9 +77,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteBoarI.2]
 PrefabName = RunestoneMagic
-SetAmountMin = 2
-SetAmountMax = 2
-SetChanceToDrop = 0
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 25
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -121,7 +121,7 @@ ConditionMaxLevel= 3
 
 [RRRM_EliteBoarII.1]
 PrefabName = EssenceMagic
-SetAmountMin = 3
+SetAmountMin = 2
 SetAmountMax = 3
 SetChanceToDrop = 100
 SetDropOnePerPlayer = false
@@ -131,10 +131,10 @@ ConditionMinLevel= 3
 ConditionMaxLevel= 3
 
 [RRRM_EliteBoarII.2]
-PrefabName = RunestoneRare
+PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -164,10 +164,10 @@ ConditionMinLevel= 3
 ConditionMaxLevel= 3
 
 [RRRM_EliteNeck.0]
-PrefabName = Coins
-SetAmountMin = 8
-SetAmountMax = 12
-SetChanceToDrop = 0
+PrefabName = Flint
+SetAmountMin = 1
+SetAmountMax = 5
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -178,7 +178,7 @@ ConditionMaxLevel= 1
 PrefabName = EssenceMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 100
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -189,7 +189,7 @@ ConditionMaxLevel= 1
 PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 10
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -208,10 +208,10 @@ ConditionMinLevel= 1
 ConditionMaxLevel= 1
 
 [RRRM_EliteNeck.4]
-PrefabName = Stone
+PrefabName = Feathers
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -231,9 +231,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteNeckI.1]
 PrefabName = EssenceMagic
-SetAmountMin = 2
+SetAmountMin = 1
 SetAmountMax = 2
-SetChanceToDrop = 100
+SetChanceToDrop = 75
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -242,9 +242,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteNeckI.2]
 PrefabName = RunestoneMagic
-SetAmountMin = 2
-SetAmountMax = 2
-SetChanceToDrop = 0
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 25
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -286,7 +286,7 @@ ConditionMaxLevel= 3
 
 [RRRM_EliteNeckII.1]
 PrefabName = EssenceMagic
-SetAmountMin = 3
+SetAmountMin = 2
 SetAmountMax = 3
 SetChanceToDrop = 100
 SetDropOnePerPlayer = false
@@ -296,10 +296,10 @@ ConditionMinLevel= 3
 ConditionMaxLevel= 3
 
 [RRRM_EliteNeckII.2]
-PrefabName = RunestoneRare
+PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -329,10 +329,10 @@ ConditionMinLevel= 3
 ConditionMaxLevel= 3
 
 [RRRM_EliteGreyling.0]
-PrefabName = Coins
-SetAmountMin = 8
-SetAmountMax = 12
-SetChanceToDrop = 0
+PrefabName = Resin
+SetAmountMin = 1
+SetAmountMax = 3
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -343,7 +343,7 @@ ConditionMaxLevel= 1
 PrefabName = EssenceMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 100
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -354,7 +354,7 @@ ConditionMaxLevel= 1
 PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 10
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -362,10 +362,10 @@ ConditionMinLevel= 1
 ConditionMaxLevel= 1
 
 [RRRM_EliteGreyling.3]
-PrefabName = Stone
+PrefabName = Feathers
 SetAmountMin = 1
-SetAmountMax = 1
-SetChanceToDrop = 0
+SetAmountMax = 3
+SetChanceToDrop = 100
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -396,9 +396,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteGreylingI.1]
 PrefabName = EssenceMagic
-SetAmountMin = 2
+SetAmountMin = 1
 SetAmountMax = 2
-SetChanceToDrop = 100
+SetChanceToDrop = 75
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -407,9 +407,9 @@ ConditionMaxLevel= 2
 
 [RRRM_EliteGreylingI.2]
 PrefabName = RunestoneMagic
-SetAmountMin = 2
-SetAmountMax = 2
-SetChanceToDrop = 0
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 25
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true
@@ -451,7 +451,7 @@ ConditionMaxLevel= 3
 
 [RRRM_EliteGreylingII.1]
 PrefabName = EssenceMagic
-SetAmountMin = 3
+SetAmountMin = 2
 SetAmountMax = 3
 SetChanceToDrop = 100
 SetDropOnePerPlayer = false
@@ -461,10 +461,10 @@ ConditionMinLevel= 3
 ConditionMaxLevel= 3
 
 [RRRM_EliteGreylingII.2]
-PrefabName = RunestoneRare
+PrefabName = RunestoneMagic
 SetAmountMin = 1
 SetAmountMax = 1
-SetChanceToDrop = 0
+SetChanceToDrop = 50
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
 EnableConfig = true


### PR DESCRIPTION
Update magic essense and magic ruestone drop rate for dark meadows creatures:
Magic essence: 
-- lvl1: 1 item at 50%, 
-- lvl2: 1-2 items at 75%, 
-- lvl3: 2-3 items at 100%
Magic runestone: 
-- lvl1: 1 item at 10%, 
-- lvl2: 1 item at 25%, 
-- lvl3: 1 item at 50%
Boars: 
-- Leather: 100%
-- Meat : 100%
Necks:
-- Flint: 100%
-- Feathers: 100%
Greylings: 
-- Resin: 100%
-- Feathers: 100%